### PR TITLE
Trigger hook for inner nodes

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -157,13 +157,10 @@ func (p *parser) parse(triggerHook bool) *Node {
 	case yaml_ALIAS_EVENT:
 		n = p.alias()
 	case yaml_MAPPING_START_EVENT:
-		triggerHook = false // maps are not leaf nodes, skip hook
 		n = p.mapping()
 	case yaml_SEQUENCE_START_EVENT:
-		triggerHook = false // sequences are not leaf nodes, skip hook
 		n = p.sequence()
 	case yaml_DOCUMENT_START_EVENT:
-		triggerHook = false // documents are not leaf nodes, skip hook
 		n =  p.document()
 	case yaml_STREAM_END_EVENT:
 		// Happens when attempting to decode an empty buffer.

--- a/decode_test.go
+++ b/decode_test.go
@@ -1750,12 +1750,23 @@ x:
 	c.Assert(err, IsNil)
 
 	want := map[string]string{
+		"a": "",
 		"a.b": "foo",
+		"a.c": "",
+		"a.c.d": "",
 		"a.c.d.e": "bar",
+		"f": "",
+		"f.g": "",
+		"f.g.h": "",
+		"f.g.h.i": "",
 		"f.g.h.i.0": "1",
 		"f.g.h.i.1": "2",
+		"j": "",
 		"j.k": "true",
 		"j.l": "false",
+		"x": "",
+		"x.0": "",
+		"x.1": "",
 		"x.0.z": "yes",
 		"x.0.y": "no",
 		"x.1.z": "up",

--- a/decode_test.go
+++ b/decode_test.go
@@ -1725,13 +1725,12 @@ a:
 f:
   g:
     h:
-      i:
-        - 1
-        - 2
+      i: [1,2]
 j: {"k": true, "l": false}
 
 x:
-  - z: yes
+  - z:
+      zz: yes
     y: no
   - z: up
     w: down
@@ -1749,35 +1748,39 @@ x:
 	err := dec.Decode(map[string]interface{}{})
 	c.Assert(err, IsNil)
 
-	want := map[string]string{
-		"a": "",
-		"a.b": "foo",
-		"a.c": "",
-		"a.c.d": "",
-		"a.c.d.e": "bar",
-		"f": "",
-		"f.g": "",
-		"f.g.h": "",
-		"f.g.h.i": "",
-		"f.g.h.i.0": "1",
-		"f.g.h.i.1": "2",
-		"j": "",
-		"j.k": "true",
-		"j.l": "false",
-		"x": "",
-		"x.0": "",
-		"x.1": "",
-		"x.0.z": "yes",
-		"x.0.y": "no",
-		"x.1.z": "up",
-		"x.1.w": "down",
+	// values represent a slice that contains the expected line, column and value
+	want := map[string][]interface{}{
+		"a":         {2, 1, ""},
+		"a.b":       {3, 3, "foo"},
+		"a.c":       {4, 3, ""},
+		"a.c.d":     {5, 5, ""},
+		"a.c.d.e":   {6, 7, "bar"},
+		"f":         {7, 1, ""},
+		"f.g":       {8, 3, ""},
+		"f.g.h":     {9, 5, ""},
+		"f.g.h.i":   {10, 7, ""},
+		"f.g.h.i.0": {10, 11, "1"},
+		"f.g.h.i.1": {10, 13, "2"},
+		"j":         {11, 1, ""},
+		"j.k":       {11, 5, "true"},
+		"j.l":       {11, 16, "false"},
+		"x":         {13, 1, ""},
+		"x.0":       {14, 5, ""},
+		"x.0.z":     {14, 5, ""},
+		"x.0.z.zz":  {15, 7, "yes"},
+		"x.0.y":     {16, 5, "no"},
+		"x.1":       {17, 5, ""},
+		"x.1.z":     {17, 5, "up"},
+		"x.1.w":     {18, 5, "down"},
 	}
 	c.Assert(len(got), Equals, len(want))
-	for k,v := range want {
+	for k, v := range want {
 		comment := Commentf("key: %s", k)
 		node, ok := got[k]
-		c.Assert(ok, Equals, true, comment)
-		c.Assert(node.Value, Equals, v, comment)
+		c.Check(ok, Equals, true, comment)
+		c.Check(node.Line, Equals, v[0], comment)
+		c.Check(node.Column, Equals, v[1], comment)
+		c.Check(node.Value, Equals, v[2], comment)
 	}
 }
 

--- a/yaml.go
+++ b/yaml.go
@@ -495,6 +495,17 @@ func (e *TypeError) Error() string {
 	return b.String()
 }
 
+func (e *TypeError) Unwrap() []error {
+	if len(e.Errors) == 0 {
+		return nil
+	}
+	errs := make([]error, len(e.Errors))
+	for i,err := range e.Errors {
+		errs[i] = err
+	}
+	return errs
+}
+
 type Kind uint32
 
 const (

--- a/yaml.go
+++ b/yaml.go
@@ -127,11 +127,11 @@ func (dec *Decoder) KnownFields(enable bool) {
 	dec.knownFields = enable
 }
 
-// DecoderHook is called for every leaf node and receives the node itself and
-// the path leading up to the node.
+// DecoderHook is called for every node and receives the node itself and the
+// path leading up to the node.
 type DecoderHook func(path []string, node *Node)
 
-// WithHook adds a DecoderHook that gets called for every leaf node.
+// WithHook adds a DecoderHook that gets called for every node.
 func (dec *Decoder) WithHook(h DecoderHook) {
 	dec.parser.withHook(h)
 }


### PR DESCRIPTION
This PR changes the hook so it's not triggered only for leaf nodes but also for all inner nodes. We use this in Conduit to better target linter warnings.